### PR TITLE
Repaired HTML Anchor Links

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,21 +26,21 @@
     </header> <!-- Changed from div to header here-->
     <section class="hero" aria-label="A group of team members in a digital marketing meeting"></section> <!-- Changed div to section, but kept "hero" class as this seems standard for background images. This "hero" selector links to an image; however, it is a background image. If a description is sought, could add `title="Digital marketing meeting"` or an 'aria-label'-->
     <main> <!-- Changed from div class="content" to main-->
-        <section class="search-engine-optimization"> <!-- Changed from div to section but kept class-->
+        <section id = "search-engine-optimization" class="search-engine-optimization"> <!-- Changed from div to section but kept class; added id="search-engine-optimization" to repair the anchor in the nav section-->
             <img src="./assets/images/search-engine-optimization.jpg" class="float-left" alt="Cloud labeled 'Search Engine Optimization' surrounded by topics such as 'Content', 'Headings', 'Mobile Compatibility', 'Social Media', 'Link Building', and 'Backlink'"/>
             <h2>Search Engine Optimization</h2>
             <p>
                 The dominance of mobile internet use means that users are searching for the right business as they travel, shop, or sit on their couch at home. Search Engine Optimization (SEO) allows you to increase your visibility and find the right customers for your business.
             </p>
         </section> <!-- Changed div to section-->
-        <section class="online-reputation-management">  <!-- Changed from div to section and removed the id="online-reputation-management" since we have used class to define it-->
+        <section id="online-reputation-management" class="online-reputation-management">  <!-- Changed from div to section -->
             <img src="./assets/images/online-reputation-management.jpg" class="float-right" id="Bar charts depiciting an increase in 'Reputation' as a result of online reputation management"/>
             <h2>Online Reputation Management</h2>
             <p>
                 The web is full of opinions, and some of these can be negative. Social media allows anyone with an internet connection to say whatever they want about your business. Online Reputation Management gives you the control over what potential customers see when they search for your business.
             </p>
         </section>
-        <section class="social-media-marketing"> <!-- Changed from div to section and removed the id="social-media-marketing" attribute because we have defined it as a class-->
+        <section id="social-media-marketing" class="social-media-marketing"> <!-- Changed from div to section -->
             <img src="./assets/images/social-media-marketing.jpg" class="float-left" id="A group of team members sit around a table with different types of social media interactions and content printed on pieces of paper. Examples include 'Tweet', 'Like', 'Media', and app icons for phone cameras, search buttons, music, and others"/>
             <h2>Social Media Marketing</h2>
             <p>


### PR DESCRIPTION
Added an `id=` identifier to the relevant "search-engine-optimization" section which contained a broken anchor link to scroll down the page. 

In prior pushes, the `id=online-reputation-management` and `id="social-media-marketing"` were removed from their respective sections; these identifiers have been reintroduced to repair anchor links.